### PR TITLE
Add async_shutdown docstring

### DIFF
--- a/custom_components/ai_automation_suggester/coordinator.py
+++ b/custom_components/ai_automation_suggester/coordinator.py
@@ -188,6 +188,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         self.area_registry = ar.async_get(self.hass)
 
     async def async_shutdown(self):
+        """Handle cleanup when the integration is unloaded."""
         return
 
     # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- note cleanup expectations when coordinator shuts down

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_686c2b5d6f988328abb31013cff82f61