### PR TITLE
Fix timezone setup in tests

### DIFF
--- a/tests/test_coordinator_and_sensors.py
+++ b/tests/test_coordinator_and_sensors.py
@@ -4,6 +4,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import asyncio
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 from homeassistant.loader import DATA_CUSTOM_COMPONENTS as LOADER_CUSTOM
@@ -50,6 +51,8 @@ async def test_coordinator_budgets():
         ("storage_dir" if "storage_dir" in signature(async_test_home_assistant).parameters else "config_dir"): str(repo_root)
     }
     async with async_test_home_assistant(**kwargs) as hass:
+        with patch("homeassistant.core_config.report_usage"):
+            hass.config.set_time_zone("UTC")
         hass.data.pop(LOADER_CUSTOM, None)
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -91,6 +94,8 @@ async def test_sensor_updates():
         ("storage_dir" if "storage_dir" in signature(async_test_home_assistant).parameters else "config_dir"): str(repo_root)
     }
     async with async_test_home_assistant(**kwargs) as hass:
+        with patch("homeassistant.core_config.report_usage"):
+            hass.config.set_time_zone("UTC")
         hass.data.pop(LOADER_CUSTOM, None)
         entry = MockConfigEntry(
             domain=DOMAIN,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,6 +3,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pytest
+from unittest.mock import patch
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.loader import DATA_CUSTOM_COMPONENTS as LOADER_CUSTOM
 from inspect import signature
@@ -23,6 +24,8 @@ async def test_async_setup_entry(expected_lingering_timers):
         ("storage_dir" if "storage_dir" in signature(async_test_home_assistant).parameters else "config_dir"): str(repo_root)
     }
     async with async_test_home_assistant(**kwargs) as hass:
+        with patch("homeassistant.core_config.report_usage"):
+            hass.config.set_time_zone("UTC")
         hass.data.pop(LOADER_CUSTOM, None)
         entry = MockConfigEntry(
             domain=DOMAIN,


### PR DESCRIPTION
## Summary
- ensure tests set a valid timezone before Home Assistant starts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c33e3a818832881939846cabecd06