### PR TITLE
Document test dependencies and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,9 +392,18 @@ This project requires **Python 3.11**. Install dependencies with:
 pip install -r requirements.txt
 ```
 
-The test suite relies on `pytest-homeassistant-custom-component`. Run it with:
+The test suite relies on both `Home Assistant` and the
+`pytest-homeassistant-custom-component` plugin. Install them before running
+tests:
 
 ```bash
+pip install homeassistant pytest-homeassistant-custom-component
+```
+
+You can use the provided helper script to set everything up:
+
+```bash
+bash scripts/setup_tests.sh
 pytest -q
 ```
 

--- a/scripts/setup_tests.sh
+++ b/scripts/setup_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Install dependencies for running the test suite
+
+set -e
+
+python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+python3 -m pip install homeassistant pytest-homeassistant-custom-component


### PR DESCRIPTION
## Summary
- update development setup docs with Home Assistant and pytest plugin requirements
- add a helper script to install test dependencies

## Testing
- `bash scripts/setup_tests.sh` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails to import Home Assistant)*

------
https://chatgpt.com/codex/tasks/task_e_686cd408d4e48328a29f677315daa864