### PR TITLE
Fix manifest metadata

### DIFF
--- a/custom_components/ai_automation_suggester/manifest.json
+++ b/custom_components/ai_automation_suggester/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "ai_automation_suggester",
   "name": "AI Automation Suggester",
-  "codeowners": ["@fjoelnir"],
+  "codeowners": ["@fjoelnr"],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/fjoelnir/ai_automation_suggester",
+  "documentation": "https://github.com/fjoelnr/ai_automation_suggester",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/fjoelnir/ai_automation_suggester/issues",
+  "issue_tracker": "https://github.com/fjoelnr/ai_automation_suggester/issues",
   "requirements": [
     "openai>=1.0.0,<2.0.0",
     "anthropic>=0.8.0",


### PR DESCRIPTION
## Summary
- update codeowners handle
- point docs and issues to main repo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_686ce5685bcc83288c16708802283748